### PR TITLE
Reverse hexa skills

### DIFF
--- a/ab_hexa_op/converted-hexa-stat-to-skill.js
+++ b/ab_hexa_op/converted-hexa-stat-to-skill.js
@@ -11,6 +11,11 @@ class ConvertedHexaStatToSkill extends HexaSkill {
         }
     }
 
+    calcSkillBaseTotal(inputStartingLevel) {
+        this._skillBaseTotal = 0;
+        return this._skillBaseTotal;
+    }
+
     compute() {
         this._fdPercentArray = [];
         this._totalFragmentCostArray = [];

--- a/ab_hexa_op/hexa-boost-node.js
+++ b/ab_hexa_op/hexa-boost-node.js
@@ -4,19 +4,19 @@ class HexaBoostNode extends HexaSkill {
     static #SparkBurstMaxLevel = 30;
     static #FusionMaxLevel = 30;
 
-    constructor(hexaSkillName, skillTotal) {
+    constructor(hexaSkillName, skillInputTotal) {
         switch (hexaSkillName) {
             case HexaSkillName.Spotlight:
-                super(hexaSkillName, skillTotal, HexaBoostNode.#SpotlightMaxLevel, HexaSkillFDOperationType.Add);
+                super(hexaSkillName, skillInputTotal, HexaBoostNode.#SpotlightMaxLevel, HexaSkillFDOperationType.Add);
                 break;
             case HexaSkillName.Mascot:
-                super(hexaSkillName, skillTotal, HexaBoostNode.#MascotMaxLevel, HexaSkillFDOperationType.Add);
+                super(hexaSkillName, skillInputTotal, HexaBoostNode.#MascotMaxLevel, HexaSkillFDOperationType.Add);
                 break;
             case HexaSkillName.SparkleBurst:
-                super(hexaSkillName, skillTotal, HexaBoostNode.#SparkBurstMaxLevel, HexaSkillFDOperationType.Add);
+                super(hexaSkillName, skillInputTotal, HexaBoostNode.#SparkBurstMaxLevel, HexaSkillFDOperationType.Add);
                 break;
             case HexaSkillName.Fusion:
-                super(hexaSkillName, skillTotal, HexaBoostNode.#FusionMaxLevel, HexaSkillFDOperationType.Add);
+                super(hexaSkillName, skillInputTotal, HexaBoostNode.#FusionMaxLevel, HexaSkillFDOperationType.Add);
                 break;
             default:
                 throw new TypeError("Unknown boost node being processed");

--- a/ab_hexa_op/hexa-mastery-node.js
+++ b/ab_hexa_op/hexa-mastery-node.js
@@ -5,9 +5,9 @@ class HexaMasteryNode extends HexaSkill {
     static #HexaTrinityBaseScale = 630;
     static #HexaTrinityLevelScale = 13;
 
-    constructor(hexaSkillName, skillTotal) {
+    constructor(hexaSkillName, skillInputTotal) {
         if (hexaSkillName == HexaSkillName.Trinity) {
-            super(hexaSkillName, skillTotal, HexaMasteryNode.#TrinityMaxLevel, HexaSkillFDOperationType.Add);
+            super(hexaSkillName, skillInputTotal, HexaMasteryNode.#TrinityMaxLevel, HexaSkillFDOperationType.Add);
         }
         else {
             throw new TypeError("Unknown mastery node being processed");

--- a/ab_hexa_op/hexa-origin-node.js
+++ b/ab_hexa_op/hexa-origin-node.js
@@ -17,13 +17,28 @@ class HexaOriginNode extends HexaSkill {
         HexaOriginNode.#fdPerIED = fdPerIED;
     }
 
+    #gfInputTotal;
     #gfBaseTotal;
+    #cbInputTotal;
     #cbBaseTotal;
     constructor(hexaSkillName, gfInputTotal, cbInputTotal) {
         super(hexaSkillName, gfInputTotal + cbInputTotal, HexaOriginNode.#GFMaxLevel, HexaSkillFDOperationType.Add);
 
-        this.#gfBaseTotal = gfInputTotal;
-        this.#cbBaseTotal = cbInputTotal;
+        this.#gfInputTotal = gfInputTotal;
+        this.#cbInputTotal = cbInputTotal;
+    }
+
+    calcSkillBaseTotal(inputStartingLevel) {
+        // First revert the additional ied/boss multiplier
+        let additionalMultiplier = this.#getAdditionalMultiplierAtLevel(inputStartingLevel);
+        let gfInputNoAdditional = this.#gfInputTotal / additionalMultiplier;
+        let cbInputNoAdditional = this.#cbInputTotal / additionalMultiplier;
+
+        // Then revert the skill % multipliers
+        this.#gfBaseTotal = gfInputNoAdditional / this.#getGFSkillMultiplierAtLevel(inputStartingLevel);
+        this.#cbBaseTotal = cbInputNoAdditional / this.#getCheeringBalloonsSkillMultiplierAtLevel(inputStartingLevel);
+        this._skillBaseTotal = this.#gfBaseTotal + this.#cbBaseTotal;
+        return this._skillBaseTotal;
     }
 
     #getSoundWavesScalingAtLevel(level) {

--- a/ab_hexa_op/hexa-origin-node.js
+++ b/ab_hexa_op/hexa-origin-node.js
@@ -17,13 +17,13 @@ class HexaOriginNode extends HexaSkill {
         HexaOriginNode.#fdPerIED = fdPerIED;
     }
 
-    #gfTotal;
-    #cbTotal;
-    constructor(hexaSkillName, gfTotal, cbTotal) {
-        super(hexaSkillName, gfTotal + cbTotal, HexaOriginNode.#GFMaxLevel, HexaSkillFDOperationType.Add);
+    #gfBaseTotal;
+    #cbBaseTotal;
+    constructor(hexaSkillName, gfInputTotal, cbInputTotal) {
+        super(hexaSkillName, gfInputTotal + cbInputTotal, HexaOriginNode.#GFMaxLevel, HexaSkillFDOperationType.Add);
 
-        this.#gfTotal = gfTotal;
-        this.#cbTotal = cbTotal;
+        this.#gfBaseTotal = gfInputTotal;
+        this.#cbBaseTotal = cbInputTotal;
     }
 
     #getSoundWavesScalingAtLevel(level) {
@@ -87,8 +87,8 @@ class HexaOriginNode extends HexaSkill {
     }
 
     _getScaledUpTotalAtLevel(level) {
-        let skillRawTotal = this.#gfTotal * this.#getGFSkillMultiplierAtLevel(level) +
-            this.#cbTotal * this.#getCheeringBalloonsSkillMultiplierAtLevel(level);
+        let skillRawTotal = this.#gfBaseTotal * this.#getGFSkillMultiplierAtLevel(level) +
+            this.#cbBaseTotal * this.#getCheeringBalloonsSkillMultiplierAtLevel(level);
         let additionalMultiplier = this.#getAdditionalMultiplierAtLevel(level);
         return skillRawTotal * additionalMultiplier;
     }

--- a/ab_hexa_op/hexa-skill-matrix.js
+++ b/ab_hexa_op/hexa-skill-matrix.js
@@ -69,19 +69,20 @@ class HexaSkillMatrix {
     static #lowestFragmentCostPath = [];
     static #boostyHijackPath = [];
 
-    static init(baTotal, gfTotal, cbTotal, trinityTotal,
-        spotlightTotal, mascotTotal, sbTotal, tfTotal,
+    static init(baInputTotal, gfInputTotal, cbInputTotal, gfCurrLevel,
+        trinityInputTotal, trinityCurrLevel, spotlightInputTotal, spotlightCurrLevel,
+        mascotInputTotal, mascotCurrLevel, sbInputTotal, sbCurrLevel, tfInputTotal, tfCurrLevel,
         fdPerBossDmgUnit, fdPerIEDUnit) {
 
-        HexaSkill.init(baTotal);
+        HexaSkill.init(baInputTotal);
         HexaOriginNode.init(fdPerBossDmgUnit, fdPerIEDUnit);
         HexaSkillMatrix.#HexaSkillArray = [];
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaOriginNode(HexaSkillName.GF, gfTotal, cbTotal));
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaMasteryNode(HexaSkillName.Trinity, trinityTotal));
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Spotlight, spotlightTotal));
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Mascot, mascotTotal));
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.SparkleBurst, sbTotal));
-        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Fusion, tfTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaOriginNode(HexaSkillName.GF, gfInputTotal, cbInputTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaMasteryNode(HexaSkillName.Trinity, trinityInputTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Spotlight, spotlightInputTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Mascot, mascotInputTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.SparkleBurst, sbInputTotal));
+        HexaSkillMatrix.#HexaSkillArray.push(new HexaBoostNode(HexaSkillName.Fusion, tfInputTotal));
         // Hexa Stat has no base damage
         HexaSkillMatrix.#HexaSkillArray.push(new ConvertedHexaStatToSkill(HexaSkillName.HexaStat, 0));
 
@@ -109,6 +110,9 @@ class HexaSkillMatrix {
         for (let skill of skillIterator) {
             skill.compute();
             totalMaxLevel += skill.maxLevel;
+        }
+        for (let i = 1; i <= 30; ++i) {
+            console.log(HexaSkillMatrix.#HexaSkillArray[HexaSkillName.GF.index].getFDFragmentRatioAtLevel(i, 1, 0));
         }
 
         let currLevels = HexaSkillLevellingInfo.getNewLevellingArray();

--- a/ab_hexa_op/hexa-skill.js
+++ b/ab_hexa_op/hexa-skill.js
@@ -53,7 +53,8 @@ class HexaSkill {
 
     #hexaSkillName;
     #maxLevel;
-    #skillBaseTotal;
+    #skillInputTotal;
+    _skillBaseTotal;
     #otherSkillsBaseTotal;
     #hexaSkillFDOperationType;
 
@@ -64,9 +65,9 @@ class HexaSkill {
 
     constructor(hexaSkillName, skillInputTotal, maxLevel, hexaSkillFDOperationType) {
         this.#hexaSkillName = hexaSkillName;
-        this.#hexaSkillFDOperationType = hexaSkillFDOperationType;
+        this.#skillInputTotal = skillInputTotal;
         this.#maxLevel = maxLevel;
-        this.#skillBaseTotal = skillInputTotal;
+        this.#hexaSkillFDOperationType = hexaSkillFDOperationType;
     }
 
     get hexaSkillName() {
@@ -81,8 +82,13 @@ class HexaSkill {
         return this.#maxLevel;
     }
 
+    calcSkillBaseTotal(inputStartingLevel) {
+        this._skillBaseTotal = this.#skillInputTotal / this.getSkillMultiplierAtLevel(inputStartingLevel);
+        return this._skillBaseTotal;
+    }
+
     compute() {
-        this.#otherSkillsBaseTotal = HexaSkill.#BABaseTotal - this.#skillBaseTotal;
+        this.#otherSkillsBaseTotal = HexaSkill.#BABaseTotal - this._skillBaseTotal;
 
         this._fdPercentArray = [];
         this._totalFragmentCostArray = [];
@@ -103,20 +109,13 @@ class HexaSkill {
         }
     }
 
-    reset() {
-        for (let i = 1; i <= this.maxLevel; i++) {
-            this.#currRemainingFdFragmentRatioArray[i] = (this._fdPercentArray[i] - this._fdPercentArray[currLevel])
-                / (this._totalFragmentCostArray[i] - this._totalFragmentCostArray[currLevel]);
-        }
-    }
-
     // Should return 1.something, like 1.1 to mean 10% increase from the base skill
     getSkillMultiplierAtLevel(level) {
         throw new TypeError("Unimplemented function HexaSkill.getSkillMultiplierAtLevel called");
     }
 
     _getScaledUpTotalAtLevel(level) {
-        return this.#skillBaseTotal * this.getSkillMultiplierAtLevel(level);
+        return this._skillBaseTotal * this.getSkillMultiplierAtLevel(level);
     }
 
     #calcFDPercentAtLevel(level) {

--- a/ab_hexa_op/hexa-skill.js
+++ b/ab_hexa_op/hexa-skill.js
@@ -45,16 +45,16 @@ class HexaSkillFDOperationType {
 class HexaSkill {
     // This is different from individual maxLevel, and serves for overall computations
     static LevelLimit = 30;
-    static #BATotal;
+    static #BABaseTotal;
 
-    static init(baTotal) {
-        HexaSkill.#BATotal = baTotal;
+    static init(baBaseTotal) {
+        HexaSkill.#BABaseTotal = baBaseTotal;
     }
 
     #hexaSkillName;
     #maxLevel;
-    #skillTotal;
-    #otherSkillsTotal;
+    #skillBaseTotal;
+    #otherSkillsBaseTotal;
     #hexaSkillFDOperationType;
 
     _fdPercentArray;
@@ -62,13 +62,11 @@ class HexaSkill {
     _totalFDFragmentRatioArray;
     #currRemainingFdFragmentRatioArray = [];
 
-    constructor(hexaSkillName, skillTotal, maxLevel, hexaSkillFDOperationType) {
+    constructor(hexaSkillName, skillInputTotal, maxLevel, hexaSkillFDOperationType) {
         this.#hexaSkillName = hexaSkillName;
         this.#hexaSkillFDOperationType = hexaSkillFDOperationType;
         this.#maxLevel = maxLevel;
-        this.#skillTotal = skillTotal;
-
-        this.#otherSkillsTotal = HexaSkill.#BATotal - this.#skillTotal;
+        this.#skillBaseTotal = skillInputTotal;
     }
 
     get hexaSkillName() {
@@ -84,6 +82,8 @@ class HexaSkill {
     }
 
     compute() {
+        this.#otherSkillsBaseTotal = HexaSkill.#BABaseTotal - this.#skillBaseTotal;
+
         this._fdPercentArray = [];
         this._totalFragmentCostArray = [];
         this._totalFDFragmentRatioArray = [];
@@ -116,11 +116,11 @@ class HexaSkill {
     }
 
     _getScaledUpTotalAtLevel(level) {
-        return this.#skillTotal * this.getSkillMultiplierAtLevel(level);
+        return this.#skillBaseTotal * this.getSkillMultiplierAtLevel(level);
     }
 
     #calcFDPercentAtLevel(level) {
-        let overallMultiplier = (this._getScaledUpTotalAtLevel(level) + this.#otherSkillsTotal) / HexaSkill.#BATotal;
+        let overallMultiplier = (this._getScaledUpTotalAtLevel(level) + this.#otherSkillsBaseTotal) / HexaSkill.#BABaseTotal;
         return fdMultiplierToPercent(overallMultiplier);
     }
 
@@ -155,6 +155,10 @@ class HexaSkill {
         if (targetLevel > this.#maxLevel) {
             targetLevel = this.#maxLevel;
         }
+        if (targetLevel == currLevel) {
+            return 0;
+        }
+
         let remainingFdFragmentRatio = (this._fdPercentArray[targetLevel] - this._fdPercentArray[currLevel])
         / (this._totalFragmentCostArray[targetLevel] - this._totalFragmentCostArray[currLevel]);
 

--- a/ab_hexa_op/index.html
+++ b/ab_hexa_op/index.html
@@ -36,41 +36,82 @@
                     <tr>
                         <td>
                             BA total damage<br>
-                            <input id="baTotal" type="number" step=1 value=177178798204033><br>
+                            <input id="baInputTotal" type="number" step=1 value=177178798204033><br>
                             (everything, including skills not listed here)
                         </td>
                         <td>
                             Grand Finale total<br>
-                            <input id="gfTotal" type="number" step=1 value=9613844770590><br>
+                            <input id="gfInputTotal" type="number" step=1 value=9613844770590><br>
                             (no Cheering Balloons)
                         </td>
                         <td>
                             Cheering Balloons total<br>
-                            <input id="cbTotal" type="number" step=1 value=12904838293467><br>
+                            <input id="cbInputTotal" type="number" step=1 value=12904838293467><br>
                             (not Seekers)
                         </td>
                         <td>
                             Trinity total<br>
-                            <input id="trinityTotal" type="number" step=1 value=68375556116735><br>
+                            <input id="trinityInputTotal" type="number" step=1 value=68375556116735><br>
                             (not Fusion)
                         </td>
                     </tr>
                     <tr>
                         <td>
                             Spotlight total<br>
-                            <input id="spotlightTotal" type="number" step=1 value=16005646714652>
+                            <input id="spotlightInputTotal" type="number" step=1 value=16005646714652>
                         </td>
                         <td>
                             Mascot total<br>
-                            <input id="mascotTotal" type="number" step=1 value=9327669026500>
+                            <input id="mascotInputTotal" type="number" step=1 value=9327669026500>
                         </td>
                         <td>
                             Sparkle Burst total<br>
-                            <input id="sbTotal" type="number" step=1 value=8534118929278>
+                            <input id="sbInputTotal" type="number" step=1 value=8534118929278>
                         </td>
                         <td>
                             Trinity Fusion total<br>
-                            <input id="tfTotal" type="number" step=1 value=7350389933992><br>
+                            <input id="tfInputTotal" type="number" step=1 value=7350389933992><br>
+                            (not Trinity)
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            Enter the current Hexa levels of each skill:
+            <table class="table table-bordered" style="width: auto;">
+                <tbody>
+                    <tr>
+                        <td>
+                            Grand Finale level<br>
+                            <input id="gfCurrLevel" type="number" step=1 value=1><br>
+                        </td>
+                        <td>
+                            Hexa Trinity level<br>
+                            <input id="trinityCurrLevel" type="number" step=1 value=0><br>
+                            (not Fusion)
+                        </td>
+                        <td>
+                            -blank space-<br>
+                        </td>
+                        <td>
+                            -blank space-<br>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            Hexa Spotlight level<br>
+                            <input id="spotlightCurrLevel" type="number" step=1 value=0>
+                        </td>
+                        <td>
+                            Hexa Mascot level<br>
+                            <input id="mascotCurrLevel" type="number" step=1 value=0>
+                        </td>
+                        <td>
+                            Hexa Sparkle Burst level<br>
+                            <input id="sbCurrLevel" type="number" step=1 value=0>
+                        </td>
+                        <td>
+                            Hexa Trinity Fusion level<br>
+                            <input id="tfCurrLevel" type="number" step=1 value=0><br>
                             (not Trinity)
                         </td>
                     </tr>

--- a/ab_hexa_op/index.html
+++ b/ab_hexa_op/index.html
@@ -29,7 +29,6 @@
         <h4>All initial data was shared by Boosty (ImSoBoosted) and we also had extensive discussions of the math behind.</h4>
         <hr>
         For each skill, put the total damage they did in the BA's column.<br>
-        For now, this works under the assumption that <b>only level 1 origin is unlocked</b>.
         <form onsubmit="return false">
             <table class="table table-bordered" style="width: auto;">
                 <tbody>

--- a/ab_hexa_op/main.js
+++ b/ab_hexa_op/main.js
@@ -7,21 +7,32 @@ document.addEventListener("DOMContentLoaded", function () {
         try {
             counter += 1;
 
-            let baTotal = Number(document.getElementById("baTotal").value);
-            let gfTotal = Number(document.getElementById("gfTotal").value);
-            let cbTotal = Number(document.getElementById("cbTotal").value);
-            let trinityTotal = Number(document.getElementById("trinityTotal").value);
+            let baInputTotal = Number(document.getElementById("baInputTotal").value);
+            let gfInputTotal = Number(document.getElementById("gfInputTotal").value);
+            let cbInputTotal = Number(document.getElementById("cbInputTotal").value);
+            let trinityInputTotal = Number(document.getElementById("trinityInputTotal").value);
 
-            let spotlightTotal = Number(document.getElementById("spotlightTotal").value);
-            let mascotTotal = Number(document.getElementById("mascotTotal").value);
-            let sbTotal = Number(document.getElementById("sbTotal").value);
-            let tfTotal = Number(document.getElementById("tfTotal").value);
+            let spotlightInputTotal = Number(document.getElementById("spotlightInputTotal").value);
+            let mascotInputTotal = Number(document.getElementById("mascotInputTotal").value);
+            let sbInputTotal = Number(document.getElementById("sbInputTotal").value);
+            let tfInputTotal = Number(document.getElementById("tfInputTotal").value);
+
+            let gfCurrLevel = Number(document.getElementById("gfCurrLevel").value);
+            let trinityCurrLevel = Number(document.getElementById("trinityCurrLevel").value);
+
+            let spotlightCurrLevel = Number(document.getElementById("spotlightCurrLevel").value);
+            let mascotCurrLevel = Number(document.getElementById("mascotCurrLevel").value);
+            let sbCurrLevel = Number(document.getElementById("sbCurrLevel").value);
+            let tfCurrLevel = Number(document.getElementById("tfCurrLevel").value);
+
+            console.log(gfCurrLevel, trinityCurrLevel, spotlightCurrLevel, mascotCurrLevel, sbCurrLevel, tfCurrLevel);
 
             let fdPerBossDmgUnit = Number(document.getElementById("fdPerBossDmgUnit").value);
             let fdPerIEDUnit = Number(document.getElementById("fdPerIEDUnit").value);
 
-            HexaSkillMatrix.init(baTotal, gfTotal, cbTotal, trinityTotal,
-                spotlightTotal, mascotTotal, sbTotal, tfTotal,
+            HexaSkillMatrix.init(baInputTotal, gfInputTotal, cbInputTotal, gfCurrLevel,
+                trinityInputTotal, trinityCurrLevel, spotlightInputTotal, spotlightCurrLevel,
+                mascotInputTotal, mascotCurrLevel, sbInputTotal, sbCurrLevel, tfInputTotal, tfCurrLevel,
                 fdPerBossDmgUnit, fdPerIEDUnit);
             HexaSkillMatrix.computeOptimalPaths();
 

--- a/ab_hexa_op/main.js
+++ b/ab_hexa_op/main.js
@@ -25,8 +25,6 @@ document.addEventListener("DOMContentLoaded", function () {
             let sbCurrLevel = Number(document.getElementById("sbCurrLevel").value);
             let tfCurrLevel = Number(document.getElementById("tfCurrLevel").value);
 
-            console.log(gfCurrLevel, trinityCurrLevel, spotlightCurrLevel, mascotCurrLevel, sbCurrLevel, tfCurrLevel);
-
             let fdPerBossDmgUnit = Number(document.getElementById("fdPerBossDmgUnit").value);
             let fdPerIEDUnit = Number(document.getElementById("fdPerIEDUnit").value);
 


### PR DESCRIPTION
With the current hexa skill levels input by the user, reverses their damage values to as if they only have lvl 1 origin and computes optimal path from there.